### PR TITLE
fix "copy" command from dockerfile

### DIFF
--- a/acra/acra-poisonrecordmaker.dockerfile
+++ b/acra/acra-poisonrecordmaker.dockerfile
@@ -12,5 +12,5 @@ RUN ["/bin/bash", "-c", \
         --without-packing --without-clean"]
 
 # Copy precompiled acra binaries and configs
-COPY acra-poisonrecordmaker ./
+COPY acra/acra-poisonrecordmaker ./
 ENTRYPOINT ["./acra-poisonrecordmaker"]


### PR DESCRIPTION
I'm running demo on macOS, without this change I see following error 

```
Step 4/5 : COPY acra-poisonrecordmaker ./
ERROR: Service 'acra-poisonrecordmaker' failed to build: COPY failed: stat /var/lib/docker/tmp/docker-builder974107901/acra-poisonrecordmaker: no such file or directory
```